### PR TITLE
Skip when not available packages are installed

### DIFF
--- a/src/patchers/upgrade_packages/index.ts
+++ b/src/patchers/upgrade_packages/index.ts
@@ -233,10 +233,12 @@ export class UpgradePackages extends BasePatcher {
     const notAvailablePackages = this.#detectNotAvailablePackages()
 
     if (notAvailablePackages.length > 0) {
-      this.logger.warning(
-        `The following packages are not available for AdonisJS v6: ${notAvailablePackages
+      this.logger.error(
+        `The following packages are not available yet for AdonisJS v6: \n - ${notAvailablePackages
           .map((pkg) => pkg.name)
-          .join(', ')}`
+          .join(
+            '\n - '
+          )}\nPlease wait a few weeks for the packages to be updated.\nSee : https://v6-migration.adonisjs.com/guides/introduction#official-packages-not-yet-compatible-with-v6`
       )
 
       return

--- a/tests/upgrade_packages.spec.ts
+++ b/tests/upgrade_packages.spec.ts
@@ -6,6 +6,26 @@ import { upgradePackages } from '../src/patchers/upgrade_packages/index.js'
 test.group('Upgrade Packages', (group) => {
   group.tap((t) => t.timeout(0).skip(!process.env.CI, 'Only run on CI'))
 
+  test('Skip when not available packages are installed', async ({ assert, fs }) => {
+    await fs.addTsConfig()
+    await fs.addRcFile()
+    await fs.addPackageJsonFile({
+      dependencies: {
+        '@adonisjs/limiter': '^5.0.0',
+      },
+    })
+
+    const runner = createRunner({
+      projectPath: fs.basePath,
+      patchers: [upgradePackages({ packageManager: 'pnpm' })],
+    })
+    await runner.run()
+
+    const pkgJson = await fs.contentsJson('package.json')
+
+    assert.isTrue(pkgJson.dependencies['@adonisjs/limiter'].startsWith('5'))
+  })
+
   test('Upgrade installed packages', async ({ assert, fs }) => {
     await fs.addTsConfig()
     await fs.addRcFile()

--- a/tests/upgrade_packages.spec.ts
+++ b/tests/upgrade_packages.spec.ts
@@ -23,7 +23,7 @@ test.group('Upgrade Packages', (group) => {
 
     const pkgJson = await fs.contentsJson('package.json')
 
-    assert.isTrue(pkgJson.dependencies['@adonisjs/limiter'].startsWith('5'))
+    assert.isTrue(pkgJson.dependencies['@adonisjs/limiter'].startsWith('^5'))
   })
 
   test('Upgrade installed packages', async ({ assert, fs }) => {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds a verification of not available packages before doing anything in the upgrade patch.

This avoids the upgrading process failing (caused by peer dependency mismatch) and having a corrupted installation in the end with a mix-match between AdonisJS 5 and AdonisJS 6 dependencies.