### PR TITLE
fix(upgrade): use force flag when removing packages

### DIFF
--- a/src/patchers/upgrade_packages/index.ts
+++ b/src/patchers/upgrade_packages/index.ts
@@ -78,7 +78,7 @@ export class UpgradePackages extends BasePatcher {
   }
 
   async #removePackages(packages: string[]) {
-    await execa(this.#pkgManager!, ['remove', ...packages], { cwd: this.#rootDir })
+    await execa(this.#pkgManager!, ['remove', ...packages, '--force'], { cwd: this.#rootDir })
   }
 
   async #replacePackages(entries: Array<{ old: string; name: string }>, isDev: boolean) {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR adds the use of the `--force` flag when removing packages.

This is needed to avoid an error caused by peer dependency mismatch.

```
[ error ] Error while running patcher : Command failed with exit code 1: npm remove @adonisjs/repl source-map-support youch youch-terminal
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: @adonisjs/auth@8.2.3
npm ERR! Found: @adonisjs/core@6.2.1
npm ERR! node_modules/@adonisjs/core
npm ERR!   peer @adonisjs/core@"^6.2.0" from @adonisjs/lucid@20.0.0
```